### PR TITLE
Adding unlinking feature to biosample relationship script

### DIFF
--- a/scripts/biosamples_relationships/README.md
+++ b/scripts/biosamples_relationships/README.md
@@ -1,14 +1,14 @@
 # Linking human and viral biosamples using the "derived from" relationship field
 
-This script links ``source`` (e.g. viral ENA sample) biosamples with ``target`` (e.g. human EGA sample) biosamples, using the ``derived from`` relationships field in BioSamples (e.g. ``Viral sample`` - ``derived from`` - ``Human sample``). For more information on the relationships fields, please see [BioSample's documentation](https://www.ebi.ac.uk/biosamples/docs/guides/relationships).  
+This script links/unlinks ``source`` (e.g. viral ENA sample) biosamples with ``target`` (e.g. human EGA sample) biosamples, using the ``derived from`` relationships field in BioSamples (e.g. ``Viral sample`` - ``derived from`` - ``Human sample``). For more information on the relationships fields, please see [BioSample's documentation](https://www.ebi.ac.uk/biosamples/docs/guides/relationships).  
 
-The script ``src/biosamples_relationships.py`` accepts an input file containing source and target accessions (BioSample's IDs - see [format](https://www.ebi.ac.uk/biosamples/docs/faq#_what_pattern_do_biosamples_accessions_follow)) to be linked.
+The script ``src/biosamples_relationships.py`` accepts an input file containing source and target accessions (BioSample's IDs - see [format](https://www.ebi.ac.uk/biosamples/docs/faq#_what_pattern_do_biosamples_accessions_follow)) to be linked/unlinked.
   
 This is a collaboration between the [ENA](https://www.ebi.ac.uk/ena/browser/home) and [EGA](https://ega-archive.org/).   
 
 # Input spreadsheet file format
 
-The script accepts a tab separated ``.txt`` or ``.csv`` input file containing source and target accessions (see example ``data/test_sample_accs_list.txt``).
+The script accepts a tab separated ``.txt``, ``.csv``, ``.tsv`` or ``.xlsx`` input file containing source and target accessions (see example ``data/test_sample_accs_list.txt``).
 
 The input file should contain two columns in the following order: ``source_biosample_id`` and ``target_biosample_id``, with 1 source (e.g. ENA BioSample accession) and 1 corresponding target (e.g. EGA BioSample accession) per line. See example below:
 
@@ -63,30 +63,34 @@ We recommend setting restrictive permissions on this file to ensure other users 
 
 ## Usage options
 
-    optional arguments:
-        -h, --help            show this help message and exit
-        -s SPREADSHEET, --spreadsheet-file SPREADSHEET
-                                (required) filename for spreadsheet (csv or .txt) containing source and target biosample accessions, with 1 source and 1 corresponding target accession per line.
-        -c [CREDENTIALS_FILE], --credentials-file [CREDENTIALS_FILE]
-                                (optional) JSON file containing the credentials (either root or original owner credentials - see data/test_credentials.json for its format) for the linkage to be pushed (default: "credentials.json"). If not given, environment variables 'bsd_username' and 'bsd_password' will be used.
-        -prod, --production   (optional) link biosamples in production (if -prod not specified, biosamples will be linked in development by default).
-        --verbose             A boolean switch to add verbosity to the scripts (printing initial token, source and target lists...)
-  
+```
+optional arguments:
+-h, --help            show this help message and exit
+-s SPREADSHEET, --spreadsheet-file SPREADSHEET
+                        (required) filename for spreadsheet (.csv, .txt, .tsv or .xlsx) containing source and target biosample accessions, with 1 source and 1 corresponding target accession per line. The two expected column headers are 'source_biosample_id' and 'target_biosample_id'.
+-c [CREDENTIALS_FILE], --credentials-file [CREDENTIALS_FILE]
+                        (optional) JSON file containing the credentials (either root or original owner credentials - see data/test_credentials.json for its format) for the changes to be pushed (default: credentials.json). If not given, environment variables 'bsd_username' and 'bsd_password' will be used.
+-u, --unlink-samples  (optional) remove relationships specified within the spreadsheet file. These are deleted at the source samples.
+-prod, --production   (optional) Changes (either link or unlink biosamples) are made in production (if -prod not specified, biosamples will be linked in development by default).
+--verbose             A boolean switch to add verbosity to the scripts (printing initial token, source and target lists...).
+```  
 
 ## Examples
 
-Example 1: link biosamples in **development** environment:`
-````
-python3 src/biosamples_relationships.py -s data/test_sample_accs_list.txt -c credentials.json --verbose
-````
-Example 2: link biosamples in **production**:
-````
-python3 src/biosamples_relationships.py -s data/test_sample_accs_list.txt -c credentials.json --verbose -prod
-````
-    
+```
+Example 1: link biosamples in development environment:
+    python3 biosamples_relationships.py -s test_sample_accs.txt
+Example 2: link biosamples in production:
+    python3 biosamples_relationships.py -s test_sample_accs.txt -prod
+Example 3: unlink biosamples in development environment:
+    python3 biosamples_relationships.py -u -s test_sample_accs.txt
+```        
+
 # Output
 There are 2 output files produced for each source biosample:
-- a source biosample json
-- a linked source biosample json 
+- A source biosample JSON
+- A modified (with the new relationships if linking; without the specified relationships if unlinking) source biosample JSON 
+
+Besides, a summary file with the timestamp is generated containing a summary of the pushed changes (exit statuses, sources, targets...)
 
 All output files are found in the ``biosamples_output`` directory. To verify that the "derived from field" has been added correctly please check the ``dev`` ([example](https://wwwdev.ebi.ac.uk/biosamples/samples/SAMEA8698068) for SAMEA8698068) or ``prod`` ([example](https://www.ebi.ac.uk/biosamples/samples/SAMN20032469) for SAMN20032469) BioSamples site.

--- a/scripts/biosamples_relationships/src/biosamples_relationships.py
+++ b/scripts/biosamples_relationships/src/biosamples_relationships.py
@@ -316,11 +316,3 @@ for source_bs in df_dict.keys():
         dt_string = now.strftime("%d-%m-%y_%H_%M_%S")
         with open(os.path.join(output_dir, f"error_{source_bs}_{dt_string}.log"), "wb") as e:
             error_file = e.write(r.content)
-
-# #
-# # how to take in several relationships sepcified in spreadsheet and remove them?
-#
-# # index = file_data["relationships"].index({'source': f'{source_bs}', 'type': 'derived from', 'target': 'SAMEA8785882'}) #target_bs not defined
-# # print(file_data.pop(["relationships"][index])) #this removes the entire relationships node? why?
-# # print(file_data["relationships"]["source"])
-        #print(file_data.pop(["relationships"][0])) #but the desired relationship to remove is not always the first one in the list

--- a/scripts/biosamples_relationships/src/biosamples_relationships.py
+++ b/scripts/biosamples_relationships/src/biosamples_relationships.py
@@ -58,32 +58,39 @@ Example 2: link biosamples in production:
     python3 biosamples_relationships.py -s test_sample_accs.txt -prod
 """
 
-parser = argparse.ArgumentParser(prog = "biosamples_relationships.py",
-                                 description = description,
-                                 formatter_class = RawTextHelpFormatter,
-                                 epilog = example
+parser = argparse.ArgumentParser(prog="biosamples_relationships.py",
+                                 description=description,
+                                 formatter_class=RawTextHelpFormatter,
+                                 epilog=example
 
-)
+                                 )
 
 parser.add_argument('-s', '--spreadsheet-file',
-                    dest = 'spreadsheet',
-                    help='(required) filename for spreadsheet (csv or .txt) containing source and target biosample accessions, with 1 source and 1 corresponding target accession per line.', 
+                    dest='spreadsheet',
+                    help='(required) filename for spreadsheet (csv or .txt) containing source and target biosample accessions, with 1 source and 1 corresponding target accession per line.',
                     type=str,
                     required=True)
 
 parser.add_argument('-c', '--credentials-file',
-                    dest = 'credentials_file',
-                    nargs = '?', # 0 or 1 arguments
-                    help = f"""(optional) JSON file containing the credentials (either root or original owner credentials - see data/test_credentials.json for its format) for the linkage to be pushed (default: "credentials.json"). If not given, environment variables '{env_user_str}' and '{env_pwd_str}' will be used.""",
-                    required = False)
+                    dest='credentials_file',
+                    nargs='?',  # 0 or 1 arguments
+                    help=f"""(optional) JSON file containing the credentials (either root or original owner credentials - see data/test_credentials.json for its format) for the linkage to be pushed (default: "credentials.json"). If not given, environment variables '{env_user_str}' and '{env_pwd_str}' will be used.""",
+                    required=False)
 
-parser.add_argument('-prod', '--production', help='(optional) link biosamples in production (if -prod not specified, biosamples will be linked in development by default).', action='store_true')  # 'dev' env is default if prod not specified
+parser.add_argument('-u', '--unlink-samples',
+                    dest='unlink',
+                    action='store_true',
+                    help=f"""(optional) remove relationships field from source samples""",
+                    required=False)
+
+parser.add_argument('-prod', '--production',
+                    help='(optional) link biosamples in production (if -prod not specified, biosamples will be linked in development by default).',
+                    action='store_true')  # 'dev' env is default if prod not specified
 
 parser.add_argument('--verbose',
                     action='store_true',
-                    default = False,
+                    default=False,
                     help="""A boolean switch to add verbosity to the scripts (printing initial token, source and target lists...)""")
-
 
 args = parser.parse_args()
 
@@ -92,37 +99,49 @@ args = parser.parse_args()
 # -------- #
 # Check that credentials file exist and is a json file:
 if not args.credentials_file == None and not os.path.isfile(args.credentials_file):
-    print(f"- ERROR in biosamples_relationships.py: given credentials file '{args.credentials_file}' does not exist.", file=sys.stderr)
+    print(f"- ERROR in biosamples_relationships.py: given credentials file '{args.credentials_file}' does not exist.",
+          file=sys.stderr)
     sys.exit()
 if not args.credentials_file == None and not os.path.splitext(args.credentials_file)[1] == ".json":
-    print(f"- ERROR in biosamples_relationships.py: given credentials file '{args.credentials_file}' is not a JSON file.", file=sys.stderr)
+    print(
+        f"- ERROR in biosamples_relationships.py: given credentials file '{args.credentials_file}' is not a JSON file.",
+        file=sys.stderr)
     sys.exit()
 
 # If a credentials file is not given, check the environmental variables
 if args.credentials_file == None:
     if not env_user_str in os.environ:
-        print(f"- ERROR in biosamples_relationships.py: no credentials file was given (option '-c'), but environmental variable '{env_user_str}' was not found either.", file=sys.stderr)
+        print(
+            f"- ERROR in biosamples_relationships.py: no credentials file was given (option '-c'), but environmental variable '{env_user_str}' was not found either.",
+            file=sys.stderr)
         sys.exit()
     if not env_pwd_str in os.environ:
-        print(f"- ERROR in biosamples_relationships.py: no credentials file was given (option '-c'), but environmental variable '{env_pwd_str}' was not found either.", file=sys.stderr)
+        print(
+            f"- ERROR in biosamples_relationships.py: no credentials file was given (option '-c'), but environmental variable '{env_pwd_str}' was not found either.",
+            file=sys.stderr)
         sys.exit()
 
 # Check that input file exists and is a .csv/.txt file:
 if not os.path.isfile(args.spreadsheet):
-    print(f"- ERROR in biosamples_relationships.py: given input file '{args.spreadsheet}' does not exist.", file=sys.stderr)
+    print(f"- ERROR in biosamples_relationships.py: given input file '{args.spreadsheet}' does not exist.",
+          file=sys.stderr)
     sys.exit()
 
 inp_file_ending = os.path.splitext(args.spreadsheet)[1]
 if not inp_file_ending == ".txt" and not inp_file_ending == ".csv":
-    print(f"- ERROR in biosamples_relationships.py: given input file '{args.spreadsheet}' is not a '.txt' or '.csv' file.", file=sys.stderr)
+    print(
+        f"- ERROR in biosamples_relationships.py: given input file '{args.spreadsheet}' is not a '.txt' or '.csv' file.",
+        file=sys.stderr)
     sys.exit()
 
 # If the chosen instance is production, check interactively that the user did intend to modify it in production.
 if interactive_check_production and args.production:
-    u_response = input("\n- WARNING: Changes will be applied to the production instance of BioSamples ('-prod' was given as an argument). Do you wish to proceed? [y/n]")
+    u_response = input(
+        "\n- WARNING: Changes will be applied to the production instance of BioSamples ('-prod' was given as an argument). Do you wish to proceed? [y/n]")
     if not u_response == "y":
         print("\t Aborting script.")
         sys.exit()
+
 
 # -------- #
 # Code blocks
@@ -133,17 +152,18 @@ def print_v(text_to_print):
     if args.verbose:
         print(text_to_print)
 
+
 # Reading credentials
 def load_json_file(file):
-    """ Function to load (and return) a JSON file (given as input) as a dictionary. 
+    """ Function to load (and return) a JSON file (given as input) as a dictionary.
     """
     with open(file, "r") as f:
         loaded_dict = json.load(f)
-        
+
     return loaded_dict
 
-def add_relationships(file_data, source_bs, target_list, r_type = "derived from", node_name = "relationships"): 
-    """ Fuction to add new relationships to a given node in a JSON file, based on a given source and target list. 
+def relationships(file_data, source_bs, target_list, r_type="derived from", node_name="relationships"):
+    """ Fuction to add new relationships to a given node in a JSON file, based on a given source and target list.
         Returns a list of new relationships that can be used to update the file.
 
         Parameters:
@@ -153,25 +173,21 @@ def add_relationships(file_data, source_bs, target_list, r_type = "derived from"
             - r_type (string): type of relationship (by default 'derived from')
             - node_name (string): node of the JSON file to add relationships to (by default 'relationships').
     """
-    # We check if the node ("relationships") already exists in the JSON file.
+
+ # We check if the node ("relationships") already exists in the JSON file.
     if node_name in file_data:
         rel_list = file_data[node_name]
     else:
         rel_list = []
 
     for target_bs in target_list:
-        new_relationship = {"source": source_bs, "type": r_type, "target": target_bs}    
+        global new_relationship
+        new_relationship = {"source": source_bs, "type": r_type, "target": target_bs}
 
-        # We append the new relationship to the list (only if it's not already there) and update the JSON file
-        if new_relationship in rel_list:
-            print_v(f"- WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' already existed in the downloaded JSON file. Skipping.")
-            continue    
-        rel_list.append(new_relationship)
-    
     return rel_list
 
 if not args.credentials_file == None:
-    credentials_dict = load_json_file(file = args.credentials_file)
+    credentials_dict = load_json_file(file=args.credentials_file)
     credentials_user = credentials_dict[user_str]
     credentials_pwd = credentials_dict[pwd_str]
 else:
@@ -180,38 +196,43 @@ else:
 
 # Check if output_dir where the output_xml will reside exists, create it if not.
 #   Get the root directory of the tool.
-root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-output_dir = os.path.join(root_dir, output_dir_name)
-dir_exists = os.path.isdir(output_dir)
+root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))  # prints root directory
+output_dir = os.path.join(root_dir, output_dir_name)  # creates biosamples_output folder in root directory
+dir_exists = os.path.isdir(output_dir)  # T or F
 if not dir_exists and output_dir != '':
     try:
         os.makedirs(output_dir)
         print_v(f"Successfully created output directory '{output_dir}'.")
     except:
-        print(f"\n- ERROR in biosamples_relationships.py: could not create output directory '{output_dir}'. Aborting script.", file=sys.stderr)
-        exit()   
+        print(
+            f"\n- ERROR in biosamples_relationships.py: could not create output directory '{output_dir}'. Aborting script.",
+            file=sys.stderr)
+        exit()
 
 # Obtaining Webin auth token
-data = json.dumps(dict([("authRealms", [ "ENA" ]), ("password", credentials_pwd), ("username", credentials_user)]))
-response = requests.post(auth_url, headers = header, data = data)
-token = response.content.decode('utf-8') # To decode from bytes (indicated by b') to string
+data = json.dumps(dict([("authRealms", ["ENA"]), ("password", credentials_pwd), ("username", credentials_user)]))
+response = requests.post(auth_url, headers=header, data=data)
+token = response.content.decode('utf-8')  # To decode from bytes (indicated by b') to string
 
-headers = {"Content-Type": "application/json;charset=UTF-8", "Accept": "application/hal+json", "Authorization": "Bearer {0}".format(token)}
+headers = {"Content-Type": "application/json;charset=UTF-8", "Accept": "application/hal+json",
+           "Authorization": "Bearer {0}".format(token)}
 print_v(f"Obtained token is:\n{token}\n")
 
 if response.status_code != 200:
     response_content = response.content.decode('utf-8')
-    print(f"\n - ERROR when generating token. Aborting script. See response's content below:\n{response_content}", file=sys.stderr)
+    print(f"\n - ERROR when generating token. Aborting script. See response's content below:\n{response_content}",
+          file=sys.stderr)
     sys.exit()
 
-#! TBD - Add XLSX as input
+# ! TBD - Add XLSX as input
 # input list of source + target accessions:
 df = pd.read_csv(args.spreadsheet, sep='\t')
 print_v(f"Input accession list (sources and targets that will be linked):\n{df}\n")
 df_dict = {}
 for source_bs, target in zip(df[source_col_name], df[target_col_name]):
     if source_bs not in df_dict:
-        df_dict[source_bs] = [target]
+        df_dict[source_bs] = [target] #list of target accessions
+
     else:
         df_dict[source_bs].append(target)
 
@@ -224,38 +245,82 @@ else:
 for source_bs in df_dict.keys():
     # Iterate over the dictionary keys (the source BSD IDs) and their lists of targets
     biosamples_url = "{0}{1}".format(biosamples_start, source_bs)
-    r = requests.get(biosamples_url) # No auth token needed
+    r = requests.get(biosamples_url)  # No auth token needed
     source_json_file = os.path.join(output_dir, f"{source_bs}.json")
     with open(source_json_file, "w") as f:
-        f.write(r.text) # Saves sample json object to file
-    
-# Edit SOURCE/ENA sample metadata to include relationships block
+        f.write(r.text)  # Saves sample json object to file
+
     file_data = json.loads(r.text)
-    file_data.pop("_links") # Removes links array (will be added automatically after updating the biosample)
+    file_data.pop("_links")  # Removes links array (will be added automatically after updating the biosample)
 
     # We call the function that returns the list of relationships
-    rel_list = add_relationships(file_data = file_data, 
-                                 source_bs = source_bs, 
-                                 target_list = df_dict[source_bs])
+    rel_list = relationships(file_data=file_data,
+                             source_bs=source_bs,
+                             target_list=df_dict[source_bs])
 
-    # We overwrite the relationships node in our array and file
-    rel_array = {"relationships": rel_list}
-    file_data.update(rel_array)
+    target_bs = new_relationship['target'] #setting target_bs variable here
 
-    edited_source_file = os.path.join(output_dir, f"linked_{source_bs}.json")
-    with open(edited_source_file, 'w') as f:
-        json.dump(file_data, f, indent = 1) # Converts python dictionary back into json string
+    # Editing SOURCE/ENA sample metadata to link samples:
+    if not args.unlink:
+        # We first append the new relationship to the list (only if it's not already there)
+        if new_relationship in rel_list:
+            print_v(f"- WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' already existed in the downloaded JSON file. Skipping.") #notdefined- why?
+            continue
+        rel_list.append(new_relationship)
 
-# Submit updated Biosample json file:    
-    update_url = "{0}{1}".format(biosamples_url, webin_auth)  
+        # We overwrite the relationships node in our array and file
+        rel_array = {"relationships": rel_list}
+        file_data.update(rel_array)
+
+        # We update the JSON file with the new relationships
+        edited_source_file = os.path.join(output_dir, f"linked_{source_bs}.json")
+        with open(edited_source_file, 'w') as f:
+            json.dump(file_data, f, indent=1)  # Converts python dictionary back into json string
+
+    # Editing SOURCE/ENA sample metadata to unlink samples:
+    elif args.unlink:
+        #interactive check whether user would really like to remove unlink samples
+        user_response = input(f" - \n WARNING: Relationship between source sample '{source_bs}' derived from target sample '{target_bs}' will be removed. Do you wish to proceed? [y/n]")
+        if not user_response == "y":
+            print("\t Aborting script.")
+            sys.exit()
+        # Remove relationships between source + target accs
+        try:
+            index = file_data["relationships"].index(new_relationship)
+            file_data["relationships"].pop(index) # removing nested lists using integers not strings
+        except: #except if ValueError thrown
+            print(f"WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' does not exist in the downloaded JSON file. Skipping.")
+            continue
+
+        # We update the JSON file by removing the relationships
+        edited_source_file = os.path.join(output_dir, f"unlinked_{source_bs}.json")
+        with open(edited_source_file, 'w') as f:
+            json.dump(file_data, f, indent=1)  # Converts python dictionary back into json string
+
+    # Submit updated Biosample json file:
+    update_url = "{0}{1}".format(biosamples_url, webin_auth)
     r = requests.put(update_url, headers = headers, data = json.dumps(file_data))
 
 # error messages:
     if r.status_code == 200:
-        print_v(f"-- Biosamples successfully linked. Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}")
+        if not args.unlink:
+            print_v(f"-- Biosamples successfully linked. Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}")
+        elif args.unlink:
+            print_v(f"-- Biosamples successfully unlinked. The following relationship has been removed: 'Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}'")
     else:
-        print(f"- ERROR: Biosamples linking failed (error code {r.status_code}). See error file. For Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}", file=sys.stderr)
+        if not args.unlink:
+            print(f"- ERROR: Biosamples linking failed (error code {r.status_code}). See error file. For Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}", file=sys.stderr)
+        elif args.unlink:
+            print(f"- ERROR: Failed to remove Biosamples relationship/s (error code {r.status_code}). See error file. For Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}", file=sys.stderr)
         now = datetime.now()
         dt_string = now.strftime("%d-%m-%y_%H_%M_%S")
         with open(os.path.join(output_dir, f"error_{source_bs}_{dt_string}.log"), "wb") as e:
             error_file = e.write(r.content)
+
+# #
+# # how to take in several relationships sepcified in spreadsheet and remove them?
+#
+# # index = file_data["relationships"].index({'source': f'{source_bs}', 'type': 'derived from', 'target': 'SAMEA8785882'}) #target_bs not defined
+# # print(file_data.pop(["relationships"][index])) #this removes the entire relationships node? why?
+# # print(file_data["relationships"]["source"])
+        #print(file_data.pop(["relationships"][0])) #but the desired relationship to remove is not always the first one in the list

--- a/scripts/biosamples_relationships/src/biosamples_relationships.py
+++ b/scripts/biosamples_relationships/src/biosamples_relationships.py
@@ -42,7 +42,8 @@ webin_auth = "?authProvider=WEBIN"
 # Column headers to be expected at the input file:
 source_col_name = "source_biosample_id"
 target_col_name = "target_biosample_id"
-
+# Using a boolean value for unlinking samples
+run = False
 # -------- #
 # Parsing given arguments
 # -------- #
@@ -224,7 +225,7 @@ if response.status_code != 200:
           file=sys.stderr)
     sys.exit()
 
-# ! TBD - Add XLSX as input
+#! TBD - Add XLSX as input
 # input list of source + target accessions:
 df = pd.read_csv(args.spreadsheet, sep='\t')
 print_v(f"Input accession list (sources and targets that will be linked):\n{df}\n")
@@ -264,7 +265,7 @@ for source_bs in df_dict.keys():
     if not args.unlink:
         # We first append the new relationship to the list (only if it's not already there)
         if new_relationship in rel_list:
-            print_v(f"- WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' already existed in the downloaded JSON file. Skipping.") #notdefined- why?
+            print_v(f"- WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' already existed in the downloaded JSON file. Skipping.")
             continue
         rel_list.append(new_relationship)
 
@@ -278,19 +279,25 @@ for source_bs in df_dict.keys():
             json.dump(file_data, f, indent=1)  # Converts python dictionary back into json string
 
     # Editing SOURCE/ENA sample metadata to unlink samples:
+
     elif args.unlink:
-        #interactive check whether user would really like to remove unlink samples
-        user_response = input(f" - \n WARNING: Relationship between source sample '{source_bs}' derived from target sample '{target_bs}' will be removed. Do you wish to proceed? [y/n]")
-        if not user_response == "y":
-            print("\t Aborting script.")
-            sys.exit()
+        #interactive check whether user would really like to unlink samples
+        if not run:
+            user_response = input(f" - \n WARNING: All relationships specified in the spreadsheet will be removed. Do you wish to proceed? [y/n]")
+            if user_response == "y":
+                run = True #ensures user_response if statement is run only once in the for loop
+            elif user_response == "n":
+                print("\t Aborting script.")
+                sys.exit()
+
         # Remove relationships between source + target accs
         try:
-            index = file_data["relationships"].index(new_relationship)
-            file_data["relationships"].pop(index) # removing nested lists using integers not strings
-        except: #except if ValueError thrown
-            print(f"WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' does not exist in the downloaded JSON file. Skipping.")
-            continue
+            file_data["relationships"].remove(new_relationship)
+        except ValueError:
+            print(f"WARNING: Specified relationships do not exist in the downloaded JSON file. Skipping.")
+        except:  # handle all other errors
+            raise
+            sys.exit()
 
         # We update the JSON file by removing the relationships
         edited_source_file = os.path.join(output_dir, f"unlinked_{source_bs}.json")
@@ -300,13 +307,15 @@ for source_bs in df_dict.keys():
     # Submit updated Biosample json file:
     update_url = "{0}{1}".format(biosamples_url, webin_auth)
     r = requests.put(update_url, headers = headers, data = json.dumps(file_data))
+    # print(r)
+    # print(r.status_code)
 
-# error messages:
+#error messages:
     if r.status_code == 200:
         if not args.unlink:
             print_v(f"-- Biosamples successfully linked. Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}")
         elif args.unlink:
-            print_v(f"-- Biosamples successfully unlinked. The following relationship has been removed: 'Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}'")
+            print_v(f"-- Biosamples successfully unlinked. 'Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}' has been removed")
     else:
         if not args.unlink:
             print(f"- ERROR: Biosamples linking failed (error code {r.status_code}). See error file. For Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}", file=sys.stderr)
@@ -316,3 +325,7 @@ for source_bs in df_dict.keys():
         dt_string = now.strftime("%d-%m-%y_%H_%M_%S")
         with open(os.path.join(output_dir, f"error_{source_bs}_{dt_string}.log"), "wb") as e:
             error_file = e.write(r.content)
+
+#TODO:
+#create tsv listing all biosample relationships that have/have not been linked/unlinked
+#check file, and print "all biosamples linked/unlinked" if status_code = 200 for each one

--- a/scripts/biosamples_relationships/src/biosamples_relationships.py
+++ b/scripts/biosamples_relationships/src/biosamples_relationships.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python3
+#!/usr/bin/env python3
 
 # Copyright [2021] EMBL-European Bioinformatics Institute
 #
@@ -19,11 +19,9 @@ import requests
 import sys
 import pandas as pd
 import json
-from datetime import datetime, date
+from datetime import datetime
 import os
 from argparse import RawTextHelpFormatter
-import csv
-from os.path import exists
 
 # -------- #
 # Hard-coded variables
@@ -45,17 +43,24 @@ webin_auth = "?authProvider=WEBIN"
 source_col_name = "source_biosample_id"
 target_col_name = "target_biosample_id"
 # Using a boolean value for unlinking samples
-run = False
+user_response = False
 # Datetime string for error file
 now = datetime.now()
-dt_string = now.strftime("%d-%m-%y_%H_%M_%S")
+dt_string = now.strftime("%y-%m-%d_%H-%M-%S")
+# Name of the default credentials file
+credentials_json = "credentials.json"
+# Number of columns expected in the input file (for now 2 but may add the type of Relationship)
+number_input_columns = 2
+# Name of the columns in the summary dataframe
+exit_status_col = "exit_status"
+feature_col = "link_or_unlink"
+error_content_col = "extra_error_content"
 
 # -------- #
 # Parsing given arguments
 # -------- #
 description = """
-This script links source (e.g. viral ENA) biosamples with target (e.g. human EGA) biosamples, using the "derived from" relationships field (i.e. 'source sample derived from target sample').
-The script currently supports a 1:1 linking of source to target biosample. 
+This script links or unlinks source (e.g. viral ENA) biosamples with target (e.g. human EGA) biosamples, using the "derived from" relationships field (i.e. 'source sample derived from target sample').
 """
 
 example = """
@@ -63,41 +68,41 @@ Example 1: link biosamples in development environment:
     python3 biosamples_relationships.py -s test_sample_accs.txt
 Example 2: link biosamples in production:
     python3 biosamples_relationships.py -s test_sample_accs.txt -prod
+Example 3: unlink biosamples in development environment: 
+    python3 biosamples_relationships.py -u -s test_sample_accs.txt
 """
 
 parser = argparse.ArgumentParser(prog="biosamples_relationships.py",
                                  description=description,
                                  formatter_class=RawTextHelpFormatter,
-                                 epilog=example
-
-                                 )
+                                 epilog=example)
 
 parser.add_argument('-s', '--spreadsheet-file',
                     dest='spreadsheet',
-                    help='(required) filename for spreadsheet (csv or .txt) containing source and target biosample accessions, with 1 source and 1 corresponding target accession per line.',
+                    help=f"(required) filename for spreadsheet (.csv, .txt, .tsv or .xlsx) containing source and target biosample accessions, with 1 source and 1 corresponding target accession per line. The two expected column headers are '{source_col_name}' and '{target_col_name}'.",
                     type=str,
                     required=True)
 
 parser.add_argument('-c', '--credentials-file',
                     dest='credentials_file',
                     nargs='?',  # 0 or 1 arguments
-                    help=f"""(optional) JSON file containing the credentials (either root or original owner credentials - see data/test_credentials.json for its format) for the linkage to be pushed (default: "credentials.json"). If not given, environment variables '{env_user_str}' and '{env_pwd_str}' will be used.""",
+                    help=f"""(optional) JSON file containing the credentials (either root or original owner credentials - see data/test_credentials.json for its format) for the changes to be pushed (default: {credentials_json}). If not given, environment variables '{env_user_str}' and '{env_pwd_str}' will be used.""",
                     required=False)
 
 parser.add_argument('-u', '--unlink-samples',
                     dest='unlink',
                     action='store_true',
-                    help=f"""(optional) remove relationships field from source samples""",
+                    help=f"""(optional) remove relationships specified within the spreadsheet file. These are deleted at the source samples.""",
                     required=False)
 
 parser.add_argument('-prod', '--production',
-                    help='(optional) link biosamples in production (if -prod not specified, biosamples will be linked in development by default).',
+                    help='(optional) Changes (either link or unlink biosamples) are made in production (if -prod not specified, biosamples will be linked in development by default).',
                     action='store_true')  # 'dev' env is default if prod not specified
 
 parser.add_argument('--verbose',
                     action='store_true',
                     default=False,
-                    help="""A boolean switch to add verbosity to the scripts (printing initial token, source and target lists...)""")
+                    help="""A boolean switch to add verbosity to the scripts (printing initial token, source and target lists...).""")
 
 args = parser.parse_args()
 
@@ -128,19 +133,6 @@ if args.credentials_file == None:
             file=sys.stderr)
         sys.exit()
 
-# Check that input file exists and is a .csv/.txt file:
-if not os.path.isfile(args.spreadsheet):
-    print(f"- ERROR in biosamples_relationships.py: given input file '{args.spreadsheet}' does not exist.",
-          file=sys.stderr)
-    sys.exit()
-
-inp_file_ending = os.path.splitext(args.spreadsheet)[1]
-if not inp_file_ending == ".txt" and not inp_file_ending == ".csv":
-    print(
-        f"- ERROR in biosamples_relationships.py: given input file '{args.spreadsheet}' is not a '.txt' or '.csv' file.",
-        file=sys.stderr)
-    sys.exit()
-
 # If the chosen instance is production, check interactively that the user did intend to modify it in production.
 if interactive_check_production and args.production:
     u_response = input(
@@ -149,6 +141,16 @@ if interactive_check_production and args.production:
         print("\t Aborting script.")
         sys.exit()
 
+# We check that the unlinking was specified on purpose
+if args.unlink:
+    while user_response not in ("n", "y"):
+        user_response = input(" - \n WARNING: All relationships specified in the spreadsheet will be removed. Do you wish to proceed? [y/n]")
+    if user_response == "n":
+        print("\t Aborting script.")
+        sys.exit()
+    keyword_for_reporting = "un"
+else:
+    keyword_for_reporting = "" 
 
 # -------- #
 # Code blocks
@@ -159,8 +161,7 @@ def print_v(text_to_print):
     if args.verbose:
         print(text_to_print)
 
-
-# Reading credentials
+# To read credentials
 def load_json_file(file):
     """ Function to load (and return) a JSON file (given as input) as a dictionary.
     """
@@ -169,30 +170,114 @@ def load_json_file(file):
 
     return loaded_dict
 
-def relationships(file_data, source_bs, target_list, r_type="derived from", node_name="relationships"):
+def relationships(file_data, source_bs, target_list, unlink_mode, r_type="derived from", node_name="relationships"):
     """ Fuction to add new relationships to a given node in a JSON file, based on a given source and target list.
         Returns a list of new relationships that can be used to update the file.
+        If 'unlink_mode' is True, then what the function does is remove the given targets from the list of
+        relationships.
 
         Parameters:
             - file_data (JSON): JSON object to be updated.
             - source_bs (string): source of the relationship (e.g. SAMEA7616999)
             - target_list (list): list of targets of the relationship with the source (e.g. ['SAMEA6941288', 'SAMEA8698068'])
+            - unlink_mode (bool): whether the function needs to add or remove relationships. 
             - r_type (string): type of relationship (by default 'derived from')
             - node_name (string): node of the JSON file to add relationships to (by default 'relationships').
     """
 
- # We check if the node ("relationships") already exists in the JSON file.
+    # We check if the node ("relationships") already exists in the JSON file.
     if node_name in file_data:
         rel_list = file_data[node_name]
     else:
         rel_list = []
 
     for target_bs in target_list:
-        global new_relationship
-        new_relationship = {"source": source_bs, "type": r_type, "target": target_bs}
+        relationship = {"source": source_bs, "type": r_type, "target": target_bs}
+
+        if not unlink_mode:
+            # We append the new relationship to the list (only if it's not already there and
+            #   the option is not to unlink) and update the JSON file
+            if not args.unlink and relationship in rel_list:
+                print_v(f"- WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' already existed in the downloaded JSON file. Skipping.")
+                continue
+            rel_list.append(relationship)
+
+        else:
+            try:
+                # We remove the specified relationship from the list that was already in the given file_data
+                rel_list.remove(relationship)
+
+            except ValueError:
+                # If the relationship to remove is not in the source JSON:
+                print_v(f"- WARNING: at source {source_bs} target {target_bs} could not be removed because it did not exist in the source's JSON document.")
+
+            except Exception:
+                print(f"- ERROR: at source {source_bs} target {target_bs} could not be removed.")
+                raise
 
     return rel_list
 
+def read_input_file(input_file, number_input_columns = number_input_columns):
+    """
+        Transforms the input file into a dataframe, converging from different input file
+            types (.csv, .tsv and .xlsx) into a unified format.
+
+        Regarding datatypes (dtype), we choose to preserve data as stored in the input file (dtype = "object") instead
+            of letting pandas interpret it or giving a dictionary with datatypes.
+
+        Parameters:
+            - input_file (str): filepath of the input file containing the spreadsheet. 
+            - number_input_columns (int): number of columns expected in the input file.
+    """
+    # We check the given filepath exists and is a file
+    if not os.path.isfile(input_file):
+        print("- ERROR in read_input_file(): given input filepath '%s' does not exist" % input_file, file=sys.stderr)
+        sys.exit()
+    
+    input_filetype = os.path.splitext(input_file)[1]
+    input_file_basename = os.path.basename(input_file)
+
+    if not input_filetype.lower() in [".txt", ".xlsx", ".tsv", ".csv"]:
+        print(
+            f"- ERROR in biosamples_relationships.py: given input file '{args.spreadsheet}' is not a '.txt', '.csv', '.tsv' or '.xlsx' file.",
+            file=sys.stderr)
+        sys.exit()    
+
+    try:
+        # Depending on what filetype it is, we read it with different pandas' methods
+        if input_filetype == ".csv":
+            input_dataframe = pd.read_csv(filepath_or_buffer = input_file, sep = ",", dtype = "object")
+
+        elif input_filetype == ".tsv" or input_filetype == ".txt":
+            input_dataframe = pd.read_csv(filepath_or_buffer = input_file, sep = "\t", dtype = "object")
+
+        elif input_filetype == ".xlsx":
+            input_dataframe = pd.read_excel(io = input_file, dtype = "object", engine='openpyxl')
+
+        else:
+            # If given a filetype that we didn't expect
+            print("ERROR in read_input_file(): given input file (%s) has extension '%s', while the allowed file types are [.csv | .tsv | .txt | .xlsx]" \
+                    % (input_file_basename, input_filetype), file=sys.stderr)
+            sys.exit()
+
+    except ValueError:
+        print("ERROR in read_input_file() - generate_dataframe(): given input file (%s) did not have the expected tab" \
+                    % (input_file_basename), file=sys.stderr)
+        sys.exit()
+        
+    except Exception:
+        print("ERROR in read_input_file(): given input filepath '%s' could not be read." % input_file, file=sys.stderr)
+        raise
+    
+    # We assert that there are only 'number_input_columns' number of columns (above defined) in the dataframe.
+    column_number = len(input_dataframe.columns)
+    if column_number != number_input_columns:
+        print(f"ERROR in read_input_file(): input file {input_file_basename} had {column_number} columns, but {number_input_columns} are expected.", file=sys.stderr)
+        sys.exit()
+
+    return input_dataframe
+
+# We load credentials
 if not args.credentials_file == None:
     credentials_dict = load_json_file(file=args.credentials_file)
     credentials_user = credentials_dict[user_str]
@@ -200,6 +285,9 @@ if not args.credentials_file == None:
 else:
     credentials_user = os.environ[env_user_str]
     credentials_pwd = os.environ[env_pwd_str]
+
+# We create the dataframe to record exit statuses
+summary_df = pd.DataFrame(columns = [feature_col, exit_status_col, source_col_name, target_col_name, error_content_col])
 
 # Check if output_dir where the output_xml will reside exists, create it if not.
 #   Get the root directory of the tool.
@@ -210,9 +298,8 @@ if not dir_exists and output_dir != '':
     try:
         os.makedirs(output_dir)
         print_v(f"Successfully created output directory '{output_dir}'.")
-    except:
-        print(
-            f"\n- ERROR in biosamples_relationships.py: could not create output directory '{output_dir}'. Aborting script.",
+    except Exception:
+        print(f"\n- ERROR in biosamples_relationships.py: could not create output directory '{output_dir}'. Aborting script.",
             file=sys.stderr)
         exit()
 
@@ -231,19 +318,23 @@ if response.status_code != 200:
           file=sys.stderr)
     sys.exit()
 
-#! TBD - Add XLSX as input
-# input list of source + target accessions:
-df = pd.read_csv(args.spreadsheet, sep='\t')
+##
+#   Read input file
+##
+df = read_input_file(args.spreadsheet)
 print_v(f"Input accession list (sources and targets that will be linked):\n{df}\n")
 df_dict = {}
 for source_bs, target in zip(df[source_col_name], df[target_col_name]):
     if source_bs not in df_dict:
         df_dict[source_bs] = [target] #list of target accessions
 
+    # If the source is repeated:
     else:
         df_dict[source_bs].append(target)
 
+##
 # Download SOURCE/ENA sample metadata:
+##
 if args.production:
     biosamples_start = 'https://www.ebi.ac.uk/biosamples/samples/'
 else:
@@ -261,94 +352,41 @@ for source_bs in df_dict.keys():
     file_data.pop("_links")  # Removes links array (will be added automatically after updating the biosample)
 
     # We call the function that returns the list of relationships
-    rel_list = relationships(file_data=file_data,
-                             source_bs=source_bs,
-                             target_list=df_dict[source_bs])
+    rel_list = relationships(file_data = file_data,
+                             source_bs = source_bs,
+                             target_list = df_dict[source_bs],
+                             unlink_mode = args.unlink)
 
-    target_bs = new_relationship['target'] #setting target_bs variable here
-
-    # Editing SOURCE/ENA sample metadata to link samples:
-    if not args.unlink:
-        # We first append the new relationship to the list (only if it's not already there)
-        if new_relationship in rel_list:
-            print_v(f"- WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' already existed in the downloaded JSON file. Skipping.")
-            continue
-        rel_list.append(new_relationship)
-
-        # We overwrite the relationships node in our array and file
-        rel_array = {"relationships": rel_list}
-        file_data.update(rel_array)
-
-        # We update the JSON file with the new relationships
-        edited_source_file = os.path.join(output_dir, f"linked_{source_bs}.json")
-        with open(edited_source_file, 'w') as f:
-            json.dump(file_data, f, indent=1)  # Converts python dictionary back into json string
-
-    # Editing SOURCE/ENA sample metadata to unlink samples:
-
-    elif args.unlink:
-        #interactive check whether user would really like to unlink samples
-        if not run:
-            user_response = input(f" - \n WARNING: All relationships specified in the spreadsheet will be removed. Do you wish to proceed? [y/n]")
-            if user_response == "y":
-                run = True #ensures user_response if statement is run only once in the for loop
-            elif user_response == "n":
-                print("\t Aborting script.")
-                sys.exit()
-
-        # Remove relationships between source + target accs
-        try:
-            file_data["relationships"].remove(new_relationship)
-        except ValueError:
-            print(f"WARNING: Specified relationships do not exist in the downloaded JSON file. Skipping.")
-        except:  # handle all other errors
-            raise
-            sys.exit()
-
-        # We update the JSON file by removing the relationships
-        edited_source_file = os.path.join(output_dir, f"unlinked_{source_bs}.json")
-        with open(edited_source_file, 'w') as f:
-            json.dump(file_data, f, indent=1)  # Converts python dictionary back into json string
+    # We overwrite the relationships node in our array and file
+    rel_array = {"relationships": rel_list}
+    file_data.update(rel_array)
+    
+    # We update the JSON file with the new relationships
+    edited_source_file = os.path.join(output_dir, f"modified_{source_bs}.json")
+    with open(edited_source_file, 'w') as f:
+        json.dump(file_data, f, indent=1)  # Converts python dictionary back into json string
 
     # Submit updated Biosample json file:
     update_url = "{0}{1}".format(biosamples_url, webin_auth)
     r = requests.put(update_url, headers = headers, data = json.dumps(file_data))
 
+    # We add the output of the pushed changes to the summary dataframe
+    summary_df = summary_df.append({feature_col: "unlink" if args.unlink else "link",
+                                    exit_status_col: r.status_code,
+                                    source_col_name: source_bs,
+                                    target_col_name: df_dict[source_bs],
+                                    error_content_col: str(r.content)}, 
+                                    ignore_index = True)
+
 # creating output tsv files
-    if r.status_code == 200:
-        if not args.unlink:
-            with open(os.path.join(output_dir, "linked_samples.tsv"), 'a+', newline='') as tsv1:  # removes newlines in tsv
-                writer = csv.writer(tsv1, delimiter='\t')
-                writer.writerow([f"-- Source biosample '{source_bs}' derived from target list: {df_dict[source_bs]}", r.status_code])
-        elif args.unlink:
-            with open(os.path.join(output_dir, "unlinked_samples.tsv"), 'a+', newline='') as tsv2:
-                writer = csv.writer(tsv2, delimiter='\t')
-                writer.writerow([f"-- REMOVED source biosample '{source_bs}' derived from target list: {df_dict[source_bs]}", r.status_code])
-    else:
-        with open(os.path.join(output_dir, f"error_{dt_string}.log"), "a+") as e: #append error for each sample relationship to file
-            error_file = e.write(r.content)
+summary_file_basename = f"{dt_string}_summary.tsv"
+summary_filename = os.path.join(output_dir, summary_file_basename)
+summary_df.to_csv(path_or_buf = summary_filename, 
+                sep = "\t",
+                index = False)
 
 # check to see if all samples have been linked/unlinked successfully
-# note code below would require all output tsv's to be deleted before the script is run again
-if os.path.exists(os.path.join(output_dir, "linked_samples.tsv")):
-    df_tsv1 = pd.read_csv("linked_samples.tsv", sep='\t', header=None)
-    if len(df_tsv1) == len(df):
-        print("All Biosamples successfully linked")
-    else:
-        print("ERROR: Some Biosamples have not been linked successfully. Please see error file and try again") #name error file in error message?
-
-elif os.path.exists(os.path.join(output_dir, "unlinked_samples.tsv")):
-    df_tsv2 = pd.read_csv("unlinked_samples.tsv", sep='\t', header=None)
-    if len(df_tsv2) == len(df):
-        print("All Biosamples successfully unlinked")
-    else:
-        print("ERROR: Some Biosample relationships have not been removed successfully. Please see error file and try again")
-
-#TODO:
-#add datetime to linked/unlinked output file names
-
-
-
-
-
-
+if (summary_df[exit_status_col] == 200).all():
+    print_v(f"- All {len(df)} relationships (from {len(summary_df)} sources) successfully {keyword_for_reporting}linked")
+else:
+    print(f"- ERROR: some relationships failed to be {keyword_for_reporting}linked. Please see error file {summary_file_basename} and check exit_status different from '200'.")

--- a/scripts/biosamples_relationships/src/biosamples_relationships.py
+++ b/scripts/biosamples_relationships/src/biosamples_relationships.py
@@ -42,8 +42,7 @@ webin_auth = "?authProvider=WEBIN"
 # Column headers to be expected at the input file:
 source_col_name = "source_biosample_id"
 target_col_name = "target_biosample_id"
-# Using a boolean value for unlinking samples
-run = False
+
 # -------- #
 # Parsing given arguments
 # -------- #
@@ -225,7 +224,7 @@ if response.status_code != 200:
           file=sys.stderr)
     sys.exit()
 
-#! TBD - Add XLSX as input
+# ! TBD - Add XLSX as input
 # input list of source + target accessions:
 df = pd.read_csv(args.spreadsheet, sep='\t')
 print_v(f"Input accession list (sources and targets that will be linked):\n{df}\n")
@@ -265,7 +264,7 @@ for source_bs in df_dict.keys():
     if not args.unlink:
         # We first append the new relationship to the list (only if it's not already there)
         if new_relationship in rel_list:
-            print_v(f"- WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' already existed in the downloaded JSON file. Skipping.")
+            print_v(f"- WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' already existed in the downloaded JSON file. Skipping.") #notdefined- why?
             continue
         rel_list.append(new_relationship)
 
@@ -279,25 +278,19 @@ for source_bs in df_dict.keys():
             json.dump(file_data, f, indent=1)  # Converts python dictionary back into json string
 
     # Editing SOURCE/ENA sample metadata to unlink samples:
-
     elif args.unlink:
-        #interactive check whether user would really like to unlink samples
-        if not run:
-            user_response = input(f" - \n WARNING: All relationships specified in the spreadsheet will be removed. Do you wish to proceed? [y/n]")
-            if user_response == "y":
-                run = True #ensures user_response if statement is run only once in the for loop
-            elif user_response == "n":
-                print("\t Aborting script.")
-                sys.exit()
-
+        #interactive check whether user would really like to remove unlink samples
+        user_response = input(f" - \n WARNING: Relationship between source sample '{source_bs}' derived from target sample '{target_bs}' will be removed. Do you wish to proceed? [y/n]")
+        if not user_response == "y":
+            print("\t Aborting script.")
+            sys.exit()
         # Remove relationships between source + target accs
         try:
-            file_data["relationships"].remove(new_relationship)
-        except ValueError:
-            print(f"WARNING: Specified relationships do not exist in the downloaded JSON file. Skipping.")
-        except:  # handle all other errors
-            raise
-            sys.exit()
+            index = file_data["relationships"].index(new_relationship)
+            file_data["relationships"].pop(index) # removing nested lists using integers not strings
+        except: #except if ValueError thrown
+            print(f"WARNING: Relationship of source sample '{source_bs}' derived from target sample '{target_bs}' does not exist in the downloaded JSON file. Skipping.")
+            continue
 
         # We update the JSON file by removing the relationships
         edited_source_file = os.path.join(output_dir, f"unlinked_{source_bs}.json")
@@ -307,15 +300,13 @@ for source_bs in df_dict.keys():
     # Submit updated Biosample json file:
     update_url = "{0}{1}".format(biosamples_url, webin_auth)
     r = requests.put(update_url, headers = headers, data = json.dumps(file_data))
-    # print(r)
-    # print(r.status_code)
 
-#error messages:
+# error messages:
     if r.status_code == 200:
         if not args.unlink:
             print_v(f"-- Biosamples successfully linked. Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}")
         elif args.unlink:
-            print_v(f"-- Biosamples successfully unlinked. 'Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}' has been removed")
+            print_v(f"-- Biosamples successfully unlinked. The following relationship has been removed: 'Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}'")
     else:
         if not args.unlink:
             print(f"- ERROR: Biosamples linking failed (error code {r.status_code}). See error file. For Source sample '{source_bs}' derived from target list:\n{df_dict[source_bs]}", file=sys.stderr)
@@ -325,7 +316,3 @@ for source_bs in df_dict.keys():
         dt_string = now.strftime("%d-%m-%y_%H_%M_%S")
         with open(os.path.join(output_dir, f"error_{source_bs}_{dt_string}.log"), "wb") as e:
             error_file = e.write(r.content)
-
-#TODO:
-#create tsv listing all biosample relationships that have/have not been linked/unlinked
-#check file, and print "all biosamples linked/unlinked" if status_code = 200 for each one


### PR DESCRIPTION
Added unlinking feature to script - add '-u' flag to command to unlink samples specified in an input file, e.g.

`python test_unlinking.py -s test_sample_accs_list_3.txt -c test_credentials.json --verbose -u`

(if relationships specified in input spreadsheet do not already exist in the input file, these will be ignored)

Please also test linking and then unlinking using repeated source accessions (e.g. file below) as these do not seem to be adding/removing correctly. @M-casado 

[test_sample_accs_list_3.txt](https://github.com/enasequence/ena-content-dataflow/files/7589924/test_sample_accs_list_3.txt)

